### PR TITLE
Update distelli-manifest.yml

### DIFF
--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -3,6 +3,8 @@ bmcgehee/ipv6utility:
   OS: Ubuntu
   Env:
     - PORT: 8000
+    - ROOT_PASSWORD: "pa55w0rd"
+    - DOC_PASSWORD: "pa55w0rd"
 
   #PkgInclude:
   #  - "/*/"
@@ -15,13 +17,13 @@ bmcgehee/ipv6utility:
     
   PreInstall:
     - 'echo "Starting PreInstall for IPv6Utility"'
-    - 'sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password pa55w0rd"'
-    - 'sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password pa55w0rd"'
+    - 'sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $ROOT_PASSWORD"'
+    - 'sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $ROOT_PASSWORD"'
     - 'sudo apt-get -y install mysql-server'
     - 'sudo apt-get -y install libmysqlclient-dev'
     - 'sudo apt-get -y install python-dev'
     - 'sudo apt-get -y install python-pip'
-    - mysql -u root -ppa55w0rd -e 'create database ipv6_prefixes; GRANT ALL PRIVILEGES ON ipv6_prefixes.* TO doc@localhost IDENTIFIED BY "pa55w0rd"'
+    - mysql -u root -p$ROOT_PASSWORD -e 'create database ipv6_prefixes; GRANT ALL PRIVILEGES ON ipv6_prefixes.* TO doc@localhost IDENTIFIED BY "'"$DOC_PASSWORD"'"'
     - 'sudo pip install Django'
     - 'sudo pip install MySQL-python'
 


### PR DESCRIPTION
Extract passwords into environment variables, this is completely UNTESTED! Ideally the "root" password would be different than the "doc" password. The App should also use the $DOC_PASSWORD environment variable.

Eventually we want to support "secure" environment variables which allows customers to have these environment variables encrypted with their own private keys.
